### PR TITLE
fix: building error in nuxt & vitepress (close #3)

### DIFF
--- a/src/VueFlexWaterfall.vue
+++ b/src/VueFlexWaterfall.vue
@@ -42,7 +42,7 @@ const props = withDefaults(
 const containerHeight = ref(0);
 const winWidth = ref(0);
 const container = ref<HTMLElement>();
-const observer = new MutationObserver(() => updateOrder());
+let observer: MutationObserver;
 
 const validCol = computed(() => {
   const intCol = Number(props.col);
@@ -69,6 +69,7 @@ const throttleUpdateWidth = throttle(updateWidth, 100);
 watch(validSortedBreakAt, () => updateOrder(), { deep: true });
 
 onMounted(() => {
+  observer = new MutationObserver(() => updateOrder());
   if (validSortedBreakAt.value.length) updateWidth();
   updateOrder(false);
   watch(validCol, () => updateOrder());

--- a/src/VueFlexWaterfall.vue
+++ b/src/VueFlexWaterfall.vue
@@ -42,7 +42,7 @@ const props = withDefaults(
 const containerHeight = ref(0);
 const winWidth = ref(0);
 const container = ref<HTMLElement>();
-let observer: MutationObserver;
+let observer: MutationObserver | undefined;
 
 const validCol = computed(() => {
   const intCol = Number(props.col);
@@ -123,11 +123,11 @@ function updateWidth() {
 }
 
 function startObserve() {
-  observer.observe(container.value!, { attributes: true, childList: true, subtree: true });
+  observer?.observe(container.value!, { attributes: true, childList: true, subtree: true });
 }
 
 function stopObserve() {
-  observer.disconnect();
+  observer?.disconnect();
 }
 
 function addResizeListener() {


### PR DESCRIPTION
fix #3

This issue also affect viptepress.

```
...
rendering pages...ReferenceError: MutationObserver is not defined
    at setup (node_modules/.pnpm/vue-flex-waterfall@2.1.0/node_modules/vue-flex-waterfall/dist/vue-flex-waterfall.es.js:227:22)
...
```