### PR TITLE
fix: type exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "exports": {
     ".": {
       "import": "./dist/vue-flex-waterfall.mjs",
-      "require": "./dist/vue-flex-waterfall.umd.js"
+      "require": "./dist/vue-flex-waterfall.umd.js",
+      "types": "./dist/index.d.ts"
     }
   },
   "scripts": {


### PR DESCRIPTION
类型导出好像有问题的样子

There are types at '——/node_modules/vue-flex-waterfall/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'vue-flex-waterfall' library may need to update its package.json or typings.